### PR TITLE
Disable DPM

### DIFF
--- a/arista/platforms/a7050qx32s.py
+++ b/arista/platforms/a7050qx32s.py
@@ -34,14 +34,16 @@ class Clearlake(Platform):
          I2cKernelComponent(I2cAddr(2, 0x4c), 'max6658', '/sys/class/hwmon/hwmon2'),
          I2cKernelComponent(I2cAddr(3, 0x4c), 'max6658', '/sys/class/hwmon/hwmon3'),
          I2cKernelComponent(I2cAddr(3, 0x60), 'crow_cpld', '/sys/class/hwmon/hwmon4'),
-         I2cKernelComponent(I2cAddr(3, 0x4e), 'pmbus',
-                            priority=Priority.BACKGROUND), # ucd90120A
+         # Handling of the DPM is disabled because this functionality is unstable.
+         # I2cKernelComponent(I2cAddr(3, 0x4e), 'pmbus',
+         #                    priority=Priority.BACKGROUND), # ucd90120A
          I2cKernelComponent(I2cAddr(5, 0x58), 'pmbus',
                             priority=Priority.BACKGROUND),
          I2cKernelComponent(I2cAddr(6, 0x58), 'pmbus',
                             priority=Priority.BACKGROUND),
-         I2cKernelComponent(I2cAddr(7, 0x4e), 'pmbus',
-                            priority=Priority.BACKGROUND), # ucd90120A
+         # Handling of the DPM is disabled because this functionality is unstable.
+         # I2cKernelComponent(I2cAddr(7, 0x4e), 'pmbus',
+         #                    priority=Priority.BACKGROUND), # ucd90120A
          Ds125Br(I2cAddr(8, 0xff)),
       ])
 

--- a/arista/platforms/a7060cx32s.py
+++ b/arista/platforms/a7060cx32s.py
@@ -29,14 +29,16 @@ class Upperlake(Platform):
          I2cKernelComponent(I2cAddr(2, 0x1a), 'max6697', '/sys/class/hwmon/hwmon1'),
          I2cKernelComponent(I2cAddr(3, 0x4c), 'max6658', '/sys/class/hwmon/hwmon2'),
          I2cKernelComponent(I2cAddr(3, 0x60), 'crow_cpld', '/sys/class/hwmon/hwmon3'),
-         I2cKernelComponent(I2cAddr(3, 0x4e), 'pmbus',
-                            priority=Priority.BACKGROUND), # ucd90120A
+         # Handling of the DPM is disabled because this functionality is unstable.
+         # I2cKernelComponent(I2cAddr(3, 0x4e), 'pmbus',
+         #                    priority=Priority.BACKGROUND), # ucd90120A
          I2cKernelComponent(I2cAddr(5, 0x58), 'pmbus',
                             priority=Priority.BACKGROUND),
          I2cKernelComponent(I2cAddr(6, 0x58), 'pmbus',
                             priority=Priority.BACKGROUND),
-         I2cKernelComponent(I2cAddr(7, 0x4e), 'pmbus',
-                            priority=Priority.BACKGROUND), # ucd90120A
+         # Handling of the DPM is disabled because this functionality is unstable.
+         # I2cKernelComponent(I2cAddr(7, 0x4e), 'pmbus',
+         #                    priority=Priority.BACKGROUND), # ucd90120A
       ])
 
       scd.addSmbusMasterRange(0x8000, 5, 0x80)

--- a/arista/platforms/a7260cx364.py
+++ b/arista/platforms/a7260cx364.py
@@ -97,8 +97,9 @@ class Gardena(Platform):
       cpld.addSmbusMasterRange(0x8000, 4, 0x80, 4)
       cpld.addComponents([
          I2cKernelComponent(I2cAddr(73, 0x4c), 'max6658', '/sys/class/hwmon/hwmon2'),
-         I2cKernelComponent(I2cAddr(74, 0x4e), 'pmbus',
-                            priority=Priority.BACKGROUND),
+         # Handling of the DPM is disabled because this functionality is unstable.
+         # I2cKernelComponent(I2cAddr(74, 0x4e), 'pmbus',
+         #                    priority=Priority.BACKGROUND),
          I2cKernelComponent(I2cAddr(85, 0x60), 'rook_cpld', '/sys/class/hwmon/hwmon3'),
          I2cKernelComponent(I2cAddr(88, 0x20), 'rook_leds'),
          I2cKernelComponent(I2cAddr(88, 0x48), 'lm73'),


### PR DESCRIPTION
Handling of the DPM is disabled because this functionality is unstable.