### PR TITLE
[platform/broadcom] kernel abiname change

### DIFF
--- a/confs/sonic-platform-arista.service
+++ b/confs/sonic-platform-arista.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Arista kernel modules init
 After=local-fs.target
-Before=opennsl-modules-4.9.0-7-amd64.service
+Before=opennsl-modules-4.9.0-7-1-amd64.service
 ConditionKernelCommandLine=Aboot
 
 [Service]

--- a/confs/watchdog-stop.service
+++ b/confs/watchdog-stop.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Disable the watchdog after boot
 After=swss.service
-After=opennsl-modules-4.9.0-7-amd64.service
+After=opennsl-modules-4.9.0-7-1-amd64.service
 ConditionKernelCommandLine=sid=Gardena
 
 [Service]

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Package: drivers-sonic-platform-arista
 Architecture: amd64
 Depends:
    ${misc:Depends},
-   linux-image-4.9.0-7-amd64
+   linux-image-4.9.0-7-1-amd64
 Description: Arista kernel modules for arista platform devices such as fan, led, sfp, psu
 
 Package: python-sonic-platform-arista


### PR DESCRIPTION
This commit changes the linux kernel abiname from
4.9.0-7 to 4.9.0-7-1 for udp_l3mdev_accept kernel
patch.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>