### PR TITLE
[barefoot][platform][arista] Add sfp_type to Sfp class objects

### DIFF
--- a/arista/accessors/xcvr.py
+++ b/arista/accessors/xcvr.py
@@ -11,6 +11,9 @@ class XcvrImpl(Xcvr):
       self.name = '%s%s' % (typeStr, kwargs['xcvrId'])
       self.__dict__.update(kwargs)
 
+   def getType(self):
+      return Xcvr.typeStr(self.xcvrType)
+
    def getName(self):
       return self.name
 

--- a/arista/inventory/xcvr.py
+++ b/arista/inventory/xcvr.py
@@ -13,6 +13,9 @@ class Xcvr(InventoryInterface):
    def typeStr(cls, typeIndex):
       return ['sfp', 'qsfp', 'osfp'][typeIndex]
 
+   def getType(self):
+      raise NotImplementedError()
+
    def getName(self):
       raise NotImplementedError()
 

--- a/arista/utils/sonic_platform/sfp.py
+++ b/arista/utils/sonic_platform/sfp.py
@@ -41,6 +41,8 @@ class Sfp(SfpBase):
       self._sfp = sfp
       self._sfputil = None
 
+      self.sfp_type = sfp.getType().upper()
+
    def get_name(self):
       return self._sfp.getName()
 


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/usr/bin/xcvrd", line 1208, in <module>
    main()
  File "/usr/bin/xcvrd", line 1205, in main
    xcvrd.run()
  File "/usr/bin/xcvrd", line 1166, in run
    self.init()
  File "/usr/bin/xcvrd", line 1145, in init
    post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
  File "/usr/bin/xcvrd", line 432, in post_port_sfp_dom_info_to_db
    post_port_dom_info_to_db(logical_port_name, dom_tbl, stop_event)
  File "/usr/bin/xcvrd", line 357, in post_port_dom_info_to_db
    if platform_chassis.get_sfp(physical_port).sfp_type == 'QSFP_DD':
AttributeError: 'Sfp' object has no attribute 'sfp_type'
```
Environment
SONiC Software Version: SONiC.HEAD.729-dirty-20200727.195955
Distribution: Debian 10.4
Kernel: 4.19.0-9-2-amd64
Build commit: 89184038
