### PR TITLE
Align get_status_led to expected API

### DIFF
--- a/arista/utils/sonic_platform/psu.py
+++ b/arista/utils/sonic_platform/psu.py
@@ -36,13 +36,12 @@ class Psu(PsuBase):
          return False
       return True
 
-   def get_status_led(self, color):
+   def get_status_led(self, color=None):
       try:
-         if color != self._psu.getLed().getColor():
-            return False
+         c = self._psu.getLed().getColor();
       except (IOError, OSError, ValueError):
          return False
-      return True
+      return c == color if color else c != 'off'
 
    def get_status(self):
       return self._psu.getStatus()


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

The changes are intended to fix the following warnings:

```
Aug 18 19:23:10.981375 sonic WARNING pmon#psud[37]: Failed to get led status for psu 1
Aug 18 19:23:10.981608 sonic WARNING pmon#psud[37]: Failed to get led status for psu 2
Aug 18 19:23:13.983173 sonic WARNING pmon#psud[37]: Failed to get led status for psu 1
Aug 18 19:23:13.983319 sonic WARNING pmon#psud[37]: Failed to get led status for psu 2
```
Reproduced on SONiC.HEAD.745-dirty-20200818.151309