### PR TITLE
Use polling method to detect xcvr presence change

### DIFF
--- a/arista/utils/sonic_sfputil.py
+++ b/arista/utils/sonic_sfputil.py
@@ -48,6 +48,12 @@ def getSfpUtil():
             SfpUtilBase.__init__(self)
 
     class SfpUtilNative(SfpUtilCommon):
+        def __init__(self):
+            self.xcvr_presence_map = {}
+            xcvrs = inventory.getXcvrs()
+            for xcvr in xcvrs:
+                self.xcvr_presence_map[xcvr.xcvrId] = xcvr.getPresence()
+
         """Native Sonic SfpUtil class"""
         def get_presence(self, port_num):
             if not self._is_valid_port(port_num):
@@ -98,32 +104,25 @@ def getSfpUtil():
 
         def get_transceiver_change_event(self, timeout=0):
             xcvrs = inventory.getXcvrs()
-            epoll = select.epoll()
-            openFiles = []
             ret = {}
-            try:
-               # Clear the interrupt masks
-               for xcvr in xcvrs.values():
-                  intr = xcvr.getInterruptLine()
-                  if not intr:
-                     continue
-                  xcvr.getPresence()
-                  intr.clear()
-                  openFile = open(intr.getFile())
-                  openFiles.append((xcvr, openFile))
-                  epoll.register(openFile.fileno(), select.EPOLLIN)
-               pollRet = epoll.poll(timeout=timeout/1000. if timeout != 0 else -1)
-               if pollRet:
-                  pollRet = dict(pollRet)
-                  for xcvr, openFile in openFiles:
-                     if openFile.fileno() in pollRet:
-                        ret[str(xcvr.xcvrId)] = '1' if xcvr.getPresence() else '0'
-                  return True, ret
-            finally:
-               for _, openFile in openFiles:
-                  openFile.close()
-               epoll.close()
 
-            return True, {}
+            start_time = time.time()
+            timeout = timeout / float(1000) # convert msec to sec
+            while True:
+                for xcvr in xcvrs:
+                    presence = xcvr.getPresence()
+                    if self.xcvr_presence_map[xcvr.xcvrId] != presence:
+                        ret[str(xcvr.xcvrId)] = '1' if presence else '0'
+                        self.xcvr_presence_map[xcvr.xcvrId] = presence
 
+                if len(ret) != 0:
+                    return True, ret
+
+                if timeout != 0:
+                    elapsed_time = time.time() - start_time
+                    if elapsed_time >= timeout:
+                        return True, {}
+
+                # Poll for presence change every 1 second
+                time.sleep(1)
     return SfpUtilNative


### PR DESCRIPTION
Spurious UIO interrupt events are resulting in spurious SFP presence detection. To fix this we simply poll for Xcvr presence change