### PR TITLE
Changes to import dir structure following corresponding change to sonic-platform-common

### DIFF
--- a/arista/utils/sonic_ssd.py
+++ b/arista/utils/sonic_ssd.py
@@ -2,10 +2,10 @@
 import os
 
 # pylint: disable=import-error
-from sonic_platform_base.sonic_ssd.ssd_base import SsdBase
-from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as SsdUtilDefault
+from sonic_platform_base.sonic_storage.storage_base import StorageBase
+from sonic_platform_base.sonic_storage.ssd import SsdUtil as SsdUtilDefault
 
-class EmmcUtil(SsdBase):
+class EmmcUtil(StorageBase):
    def __init__(self, diskdev):
       self.diskdev = diskdev
       self.path = os.path.join('/sys/block', os.path.basename(diskdev))


### PR DESCRIPTION
This PR changes the import structure to match a corresponding directory rename effected by [sonic-platform-common PR #439](https://github.com/sonic-net/sonic-platform-common/pull/439).