### PR TITLE
Add LED_FP_TRICOLOR to base class

### DIFF
--- a/arista/core/sku.py
+++ b/arista/core/sku.py
@@ -16,6 +16,8 @@ class Sku(Component):
    MAX_POWER_DRAW = 0
    TYP_POWER_DRAW = 0
 
+   LED_FP_TRICOLOR = False
+
    def __init__(self, *args, **kwargs):
       self.hwApi = kwargs.pop('hwApi', None)
       super(Sku, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Fixes: [#331](https://github.com/aristanetworks/sonic-qual.msft/issues/331)

Regression due to: https://github.com/aristanetworks/sonic/commit/3c9544c9e6f34e5410907c038f171806de4318ee#diff-db174f71c8d30281408b6f140bc8c232dc69d1394d28bb0a6320208712e0af0fR27

This caused unexpected syslogs 

```
E               Failed: Processes "['analyze_logs--<MultiAsicSonicHost bjw-can-7260-14>']" failed with exit code "1"
E               Exception:
E               match: 4
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               Nov 19 07:28:41.062861 bjw-can-7260-14 ERR pmon#ledd[31]: Failed to load ledutil: Failed to instantiate 'LedControl' class: 'Gardena' object has no attribute 'LED_FP_TRICOLOR'
E               
E               Nov 19 07:28:42.826540 bjw-can-7260-14 ERR pmon#ledd[75]: Failed to load ledutil: Failed to instantiate 'LedControl' class: 'Gardena' object has no attribute 'LED_FP_TRICOLOR'
E               
E               Nov 19 07:28:46.168558 bjw-can-7260-14 ERR pmon#ledd[92]: Failed to load ledutil: Failed to instantiate 'LedControl' class: 'Gardena' object has no attribute 'LED_FP_TRICOLOR'
E               
E               Nov 19 07:28:49.601844 bjw-can-7260-14 ERR pmon#ledd[121]: Failed to load ledutil: Failed to instantiate 'LedControl' class: 'Gardena' object has no attribute 'LED_FP_TRICOLOR'
E               
E               Traceback:
```